### PR TITLE
Fixing Buffer call that is causing the lambda function to fail

### DIFF
--- a/Chapter3/index.js
+++ b/Chapter3/index.js
@@ -4,7 +4,7 @@ console.log('Loading function');
 exports.handler = (event, context, callback) => {
     /* Process the list of records and transform them */
     
-    let buff = new Buffer('\n');  
+    let buff = Buffer.from('\n');
     let base64data = buff.toString('base64');
     
     const output = event.records.map((record) => ({


### PR DESCRIPTION
The proposed code for the lab is causing the lambda function to fail with the following error:

`[DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues.`

The `new Buffer` call was deprecated (more information available [here](https://nodejs.org/en/docs/guides/buffer-constructor-deprecation/)).

I've updated the code with the up to date implementation.